### PR TITLE
Update version for v1.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,8 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+### v1.0.1
+- Add the missing `log4js` to the dependencies in the `package.son` file.
+
 ### v1.0.0
 - Implement the HtmlFormatter to write the output into a html file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-webos",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./src/index.js",
     "type": "module",
     "exports": {


### PR DESCRIPTION
- Update the version and release notes for the release.
  I need to release version v1.0.1 to apply the https://github.com/iLib-js/ilib-lint-webos/pull/2 change.